### PR TITLE
feature: add names

### DIFF
--- a/src/getNames.test.ts
+++ b/src/getNames.test.ts
@@ -1,0 +1,40 @@
+import HandleDataChange from "./index";
+
+it("should create names", () => {
+  type Data = { foo?: string; bar: number };
+  const name = "handle-change-data";
+  const data = new HandleDataChange<Data>(
+    { bar: 0 },
+    (value: Data) => console.log(value),
+    name
+  );
+
+  expect(data.name.bar).toBe(name + "." + "bar");
+  expect(data.name.foo).toBe(name + "." + "foo");
+});
+
+it("should create names in nested structures", () => {
+  type Nested = {
+    someNumber: number;
+    someOther: any;
+    complex: { a: string; b: string };
+  };
+  type Data = { foo?: Nested; bar: number };
+  const name = "handle-change-data";
+  const data = new HandleDataChange<Data>(
+    { bar: 0 },
+    (value: Data) => console.log(value),
+    name
+  );
+
+  const nested = new HandleDataChange<Nested>(
+    { someNumber: 3, someOther: "a", complex: { a: "a", b: "b" } },
+    (value: Nested) => console.log(value),
+    data.name.foo
+  );
+
+  const pre = name + "." + "foo";
+  expect(nested.name.complex).toBe(pre + "." + "complex");
+  expect(nested.name.someOther).toBe(pre + "." + "someOther");
+  expect(nested.name.someNumber).toBe(pre + "." + "someNumber");
+});

--- a/src/getNames.ts
+++ b/src/getNames.ts
@@ -1,0 +1,14 @@
+export function getNames<D>(name: string, prefix: string) {
+  return new Proxy({} as names<D>, {
+    get(target: names<D>, key: keyof D): string {
+      if ((target[key] as any) === undefined) {
+        target[key] = name + prefix + key;
+      }
+      return target[key];
+    }
+  });
+}
+
+export type names<T> = { [K in keyof T]: string };
+
+export default getNames;

--- a/src/getNames.ts
+++ b/src/getNames.ts
@@ -2,7 +2,7 @@ export function getNames<D>(name: string, prefix: string) {
   return new Proxy({} as names<D>, {
     get(target: names<D>, key: keyof D): string {
       if ((target[key] as any) === undefined) {
-        target[key] = name + prefix + key;
+        target[key] = name.concat(prefix).concat(key.toString());
       }
       return target[key];
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 import dynamicOnChange from "dynamic-on-change";
-import getNames from "./getNames";
+import getNames, { names } from "./getNames";
 
 export class HandleDataChange<D> {
   private _Data: D;
-  private _name: string;
-  private _prefix: string;
   constructor(
     data: D,
     private _onChange: (newData: D) => void,
@@ -12,14 +10,13 @@ export class HandleDataChange<D> {
     prefix?: string
   ) {
     this._Data = Object.assign({}, data);
-    this._name = name || "data";
-    this._prefix = prefix || ".";
+    this.name = getNames<D>(name || "data", prefix || ".");
   }
   public change = dynamicOnChange<Required<D>>((key, value) => {
     this._Data[key] = value;
     this._onChange(this._Data);
   });
-  public name = getNames<D>(this._name, this._prefix);
+  public name: names<D>;
 }
 
 export default HandleDataChange;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,25 @@
 import dynamicOnChange from "dynamic-on-change";
+import getNames from "./getNames";
 
 export class HandleDataChange<D> {
   private _Data: D;
-  constructor(data: D, private _onChange: (newData: D) => void) {
+  private _name: string;
+  private _prefix: string;
+  constructor(
+    data: D,
+    private _onChange: (newData: D) => void,
+    name?: string,
+    prefix?: string
+  ) {
     this._Data = Object.assign({}, data);
+    this._name = name || "data";
+    this._prefix = prefix || ".";
   }
   public change = dynamicOnChange<Required<D>>((key, value) => {
     this._Data[key] = value;
     this._onChange(this._Data);
   });
+  public name = getNames<D>(this._name, this._prefix);
 }
 
 export default HandleDataChange;


### PR DESCRIPTION
It creates names in nested data components  
From the test file:
```js
  type Nested = {
    someNumber: number;
    someOther: any;
    complex: { a: string; b: string };
  };
  type Data = { foo?: Nested; bar: number };
  const name = "handle-change-data";
  const data = new HandleDataChange<Data>(
    { bar: 0 },
    (value: Data) => console.log(value),
    name
  );

  const nested = new HandleDataChange<Nested>(
    { someNumber: 3, someOther: "a", complex: { a: "a", b: "b" } },
    (value: Nested) => console.log(value),
    data.name.foo
  );

  const pre = name + "." + "foo";
  expect(nested.name.complex).toBe(pre + "." + "complex");
  expect(nested.name.someOther).toBe(pre + "." + "someOther");
  expect(nested.name.someNumber).toBe(pre + "." + "someNumber");
```